### PR TITLE
listByQuery function

### DIFF
--- a/.changeset/better-birds-double.md
+++ b/.changeset/better-birds-double.md
@@ -1,0 +1,5 @@
+---
+"@bdbchgg/winget": patch
+---
+
+Added new `listByQuery` function for winget`

--- a/docs.md
+++ b/docs.md
@@ -72,4 +72,18 @@ findOffsetsFromHeaderLine(line: string): Array<{ from: number; to: number; end: 
 
 ---
 
+### `listByQuery`
+
+```typescript
+listByQuery(query?: string): Promise<WingetListOutput[]>
+```
+
+**Description**: Lists installed packages using the Winget CLI and parses the output.
+
+**Returns**: A promise that resolves to an array of Winget list results.
+
+**Throws**: An error if the Winget CLI command fails.
+
+---
+
 For more details, refer to the source code or contact the maintainer.

--- a/src/lib/listByQuery.test.ts
+++ b/src/lib/listByQuery.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { exec } from 'child_process';
+import { listByQuery } from './listByQuery';
+
+const defaultMockStd = `
+Name                                    ID                                  Version      Verfügbar    Quelle
+------------------------------------------------------------------------------------------------------------
+Brave                                   BraveSoftware.Brave                 138.0.1                   winget
+Mozilla Firefox                         Mozilla.Firefox                     138.0.1                   winget
+Mozilla Firefox (Nightly)               Mozilla.Firefox.Nightly             139.0.1                   winget
+`;
+
+const withUpgradesMockStd = `
+Name                                    ID                                  Version      Verfügbar    Quelle
+------------------------------------------------------------------------------------------------------------
+Brave                                   BraveSoftware.Brave                 138.0.1      138.2.1      winget
+Mozilla Firefox                         Mozilla.Firefox                     138.0.1      138.4.1      winget
+Mozilla Firefox (Nightly)               Mozilla.Firefox.Nightly             139.0.1      139.7.5      winget
+`;
+
+const noResultMockStd = `Es wurde kein installiertes Paket gefunden, das den Eingabekriterien entspricht.`;
+
+vi.mock('child_process', () => {
+  return {
+    exec: vi.fn(),
+  };
+});
+
+describe('searchByQuery', () => {
+  const mockExec = exec as unknown as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return a correct result for a normal list', async () => {
+    mockExec.mockImplementation((_cmd, callback) => {
+      callback(null, defaultMockStd);
+    });
+
+    const result = await listByQuery();
+    expect(result).toEqual([
+      {
+        name: 'Brave',
+        id: 'BraveSoftware.Brave',
+        moniker: 'BraveSoftware.Brave',
+        version: '138.0.1',
+        availableVersion: undefined,
+        source: 'winget',
+      },
+      {
+        name: 'Mozilla Firefox',
+        id: 'Mozilla.Firefox',
+        moniker: 'Mozilla.Firefox',
+        version: '138.0.1',
+        availableVersion: undefined,
+        source: 'winget',
+      },
+      {
+        name: 'Mozilla Firefox (Nightly)',
+        id: 'Mozilla.Firefox.Nightly',
+        moniker: 'Mozilla.Firefox.Nightly',
+        version: '139.0.1',
+        availableVersion: undefined,
+        source: 'winget',
+      },
+    ]);
+  });
+
+  it('should return a correct result for a upgradable list', async () => {
+    mockExec.mockImplementation((_cmd, callback) => {
+      callback(null, withUpgradesMockStd);
+    });
+
+    const result = await listByQuery();
+    expect(result).toEqual([
+      {
+        name: 'Brave',
+        id: 'BraveSoftware.Brave',
+        moniker: 'BraveSoftware.Brave',
+        version: '138.0.1',
+        availableVersion: '138.2.1',
+        source: 'winget',
+      },
+      {
+        name: 'Mozilla Firefox',
+        id: 'Mozilla.Firefox',
+        moniker: 'Mozilla.Firefox',
+        version: '138.0.1',
+        availableVersion: '138.4.1',
+        source: 'winget',
+      },
+      {
+        name: 'Mozilla Firefox (Nightly)',
+        id: 'Mozilla.Firefox.Nightly',
+        moniker: 'Mozilla.Firefox.Nightly',
+        version: '139.0.1',
+        availableVersion: '139.7.5',
+        source: 'winget',
+      },
+    ]);
+  });
+
+  it('should return a correct result for no results', async () => {
+    mockExec.mockImplementation((_cmd, callback) => {
+      callback(null, noResultMockStd);
+    });
+
+    const result = await listByQuery();
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/listByQuery.ts
+++ b/src/lib/listByQuery.ts
@@ -1,0 +1,26 @@
+import { exec } from 'child_process';
+import type { WingetListOutput } from '../types';
+import parseWingetListOutput from './parseWingetListOutput';
+
+export function listByQuery(query?: string): Promise<WingetListOutput[]> {
+  const command = ['winget list'];
+
+  if (query) {
+    command.push(`--query "${query}"`);
+  }
+
+  return new Promise<WingetListOutput[]>((resolve, reject) => {
+    exec(command.join(' '), (error, stdout) => {
+      if (error) {
+        return reject(error);
+      }
+
+      try {
+        const results: WingetListOutput[] = parseWingetListOutput(stdout);
+        resolve(results);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}

--- a/src/lib/listByQuery.ts
+++ b/src/lib/listByQuery.ts
@@ -2,6 +2,13 @@ import { exec } from 'child_process';
 import type { WingetListOutput } from '../types';
 import parseWingetListOutput from './parseWingetListOutput';
 
+/**
+ * Lists installed packages using the Winget CLI and parses the output.
+ *
+ * @param {string} [query] - An optional query to filter the list of packages.
+ * @returns {Promise<WingetListOutput[]>} A promise that resolves to an array of Winget list results.
+ * @throws {Error} If the Winget CLI command fails.
+ */
 export function listByQuery(query?: string): Promise<WingetListOutput[]> {
   const command = ['winget list'];
 


### PR DESCRIPTION
This pull request introduces a new `listByQuery` function to the `@bdbchgg/winget` package, enabling users to list installed packages via the Winget CLI with optional query filtering. It also includes corresponding documentation, tests, and implementation details.

### New Feature: `listByQuery` Function

* **Implementation**: Added the `listByQuery` function in `src/lib/listByQuery.ts`, which executes the Winget CLI command to list installed packages and parses the output. The function supports an optional query parameter for filtering results.
* **Documentation**: Updated `docs.md` with a detailed description, usage example, and error-handling details for the `listByQuery` function.
* **Testing**: Added comprehensive tests in `src/lib/listByQuery.test.ts` to validate the function's behavior, including scenarios for normal lists, upgradable lists, and no results. Mocked the `exec` function for testing purposes.

### Package Update

* **Changeset**: Added a changeset file `.changeset/better-birds-double.md` to document the addition of the `listByQuery` function and specify a patch version bump for the `@bdbchgg/winget` package.