### PR TITLE
Add new options to search and list functions

### DIFF
--- a/.changeset/quick-paths-burn.md
+++ b/.changeset/quick-paths-burn.md
@@ -1,0 +1,5 @@
+---
+"@bdbchgg/winget": patch
+---
+
+Added new options argument for searchByQuery and listByQuery functions

--- a/docs.md
+++ b/docs.md
@@ -9,7 +9,7 @@ This document provides an overview of the functions available in the `@bdbchgg/w
 ### `searchByQuery`
 
 ```typescript
-searchByQuery(query: string): Promise<WingetSearchOutput[]>
+searchByQuery(query: string, options?: SearchByQueryOptions): Promise<WingetSearchOutput[]>
 ```
 
 **Description**: Searches for packages using the Winget CLI based on a query string.
@@ -17,6 +17,10 @@ searchByQuery(query: string): Promise<WingetSearchOutput[]>
 **Parameters**:
 
 - `query` (string): The search query string.
+- `options` (object, optional):
+  - `tag` (string, optional): The tag to filter by.
+  - `count` (number, optional): How many packages should be returned.
+  - `source` (string, optional): The source the package should be looked in.
 
 **Returns**: A promise that resolves to an array of Winget search results.
 
@@ -75,10 +79,18 @@ findOffsetsFromHeaderLine(line: string): Array<{ from: number; to: number; end: 
 ### `listByQuery`
 
 ```typescript
-listByQuery(query?: string): Promise<WingetListOutput[]>
+listByQuery(query?: string, options?: ListByQueryOptions): Promise<WingetListOutput[]>
 ```
 
 **Description**: Lists installed packages using the Winget CLI and parses the output.
+
+**Parameters**:
+
+- `query` (string, optional): An optional query to filter the list of packages.
+- `options` (object, optional):
+  - `tag` (string, optional): The tag to filter by.
+  - `count` (number, optional): How many packages should be returned.
+  - `source` (string, optional): The source of the package.
 
 **Returns**: A promise that resolves to an array of Winget list results.
 

--- a/src/lib/listByQuery.ts
+++ b/src/lib/listByQuery.ts
@@ -2,6 +2,19 @@ import { exec } from 'child_process';
 import type { WingetListOutput } from '../types';
 import parseWingetListOutput from './parseWingetListOutput';
 
+type Options = {
+  /** The tag to filter by */
+  tag?: string;
+
+  /** How many packages should be returned */
+  count?: number;
+
+  /** The source of the package */
+  source?: string;
+};
+
+export { Options as ListByQueryOptions };
+
 /**
  * Lists installed packages using the Winget CLI and parses the output.
  *
@@ -9,11 +22,26 @@ import parseWingetListOutput from './parseWingetListOutput';
  * @returns {Promise<WingetListOutput[]>} A promise that resolves to an array of Winget list results.
  * @throws {Error} If the Winget CLI command fails.
  */
-export function listByQuery(query?: string): Promise<WingetListOutput[]> {
+export function listByQuery(
+  query?: string,
+  options?: Options
+): Promise<WingetListOutput[]> {
   const command = ['winget list'];
 
   if (query) {
     command.push(`--query "${query}"`);
+  }
+
+  if (options?.count) {
+    command.push(`--count "${options.count}"`);
+  }
+
+  if (options?.source) {
+    command.push(`--source "${options.source}"`);
+  }
+
+  if (options?.tag) {
+    command.push(`--tag "${options.tag}"`);
   }
 
   return new Promise<WingetListOutput[]>((resolve, reject) => {

--- a/src/lib/listByQuery.ts
+++ b/src/lib/listByQuery.ts
@@ -33,7 +33,7 @@ export function listByQuery(
   }
 
   if (options?.count) {
-    command.push(`--count "${options.count}"`);
+    command.push(`--count "${options.count.toString()}"`);
   }
 
   if (options?.source) {

--- a/src/lib/listByQuery.ts
+++ b/src/lib/listByQuery.ts
@@ -32,16 +32,16 @@ export function listByQuery(
     command.push(`--query "${query}"`);
   }
 
+  if (options?.tag) {
+    command.push(`--tag "${options.tag}"`);
+  }
+
   if (options?.count) {
     command.push(`--count "${options.count.toString()}"`);
   }
 
   if (options?.source) {
     command.push(`--source "${options.source}"`);
-  }
-
-  if (options?.tag) {
-    command.push(`--tag "${options.tag}"`);
   }
 
   return new Promise<WingetListOutput[]>((resolve, reject) => {

--- a/src/lib/searchByQuery.ts
+++ b/src/lib/searchByQuery.ts
@@ -2,22 +2,53 @@ import { exec } from 'child_process';
 import type { WingetSearchOutput } from '../types';
 import parseWingetSearchOutput from './parseWingetSearchOutput';
 
+type Options = {
+  /** The tag to filter by */
+  tag?: string;
+
+  /** How many packages should be returned */
+  count?: number;
+
+  /** The source the package should be looked in */
+  source?: string;
+};
+
+export { Options as SearchByQueryOptions };
+
 /**
  * Searches for packages using the Winget CLI based on a query string.
  *
  * @param {string} query - The search query string.
+ * @param {SearchByQueryOptions} - Optional options that can be passed to the query
  * @returns {Promise<WingetSearchOutput[]>} A promise that resolves to an array of Winget search results.
  * @throws {Error} If the search query is empty or if the Winget CLI command fails.
  */
-export function searchByQuery(query: string): Promise<WingetSearchOutput[]> {
+export function searchByQuery(
+  query: string,
+  options?: Options
+): Promise<WingetSearchOutput[]> {
+  const command = ['winget search'];
+
   if (!query) {
     throw new Error('Search query is empty');
   }
 
-  const command = `winget search --query "${query}"`;
+  command.push(`--query "${query}"`);
+
+  if (options?.tag) {
+    command.push(`--tag "${options.tag}"`);
+  }
+
+  if (options?.count) {
+    command.push(`--count "${options.count.toString()}"`);
+  }
+
+  if (options?.source) {
+    command.push(`--source "${options.source}"`);
+  }
 
   return new Promise<WingetSearchOutput[]>((resolve, reject) => {
-    exec(command, (error, stdout) => {
+    exec(command.join(' '), (error, stdout) => {
       if (error) {
         return reject(error);
       }


### PR DESCRIPTION
This pull request introduces enhancements to the `searchByQuery` and `listByQuery` functions of the Winget CLI wrapper by adding optional filtering capabilities. The changes include updating the function signatures, adding new options for filtering, and updating the documentation to reflect these improvements.

### Updates to Functionality:

* **Enhanced `searchByQuery` Functionality**:
  - Added an optional `options` parameter to the `searchByQuery` function, allowing users to filter results by `tag`, `count`, and `source`. (`src/lib/searchByQuery.ts`, [src/lib/searchByQuery.tsR5-R51](diffhunk://#diff-e1d417818866e1d59f1e8b088a5e5930400e82c14c0287a806c54b73f67d0291R5-R51))
  - Updated the Winget CLI command construction to include the new filtering options. (`src/lib/searchByQuery.ts`, [src/lib/searchByQuery.tsR5-R51](diffhunk://#diff-e1d417818866e1d59f1e8b088a5e5930400e82c14c0287a806c54b73f67d0291R5-R51))

* **Enhanced `listByQuery` Functionality**:
  - Added an optional `options` parameter to the `listByQuery` function, enabling filtering by `tag`, `count`, and `source`. (`src/lib/listByQuery.ts`, [src/lib/listByQuery.tsR5-R46](diffhunk://#diff-ce7141818a8d7e47cfee99b1f86b8935227258e8f1531f922a2d219af10e2a2eR5-R46))
  - Updated the Winget CLI command construction to incorporate the new filtering options. (`src/lib/listByQuery.ts`, [src/lib/listByQuery.tsR5-R46](diffhunk://#diff-ce7141818a8d7e47cfee99b1f86b8935227258e8f1531f922a2d219af10e2a2eR5-R46))

### Documentation Updates:

* **Function Signatures**:
  - Updated the `searchByQuery` and `listByQuery` function signatures in `docs.md` to include the new `options` parameter. (`docs.md`, [[1]](diffhunk://#diff-6a042219e4779f0e778edb839c177737f9d49be99d5032a644a5ae7cded83876L12-R23) [[2]](diffhunk://#diff-6a042219e4779f0e778edb839c177737f9d49be99d5032a644a5ae7cded83876L78-R94)
  
* **Parameter Descriptions**:
  - Added detailed descriptions of the new `options` parameter and its subfields (`tag`, `count`, and `source`) in the documentation. (`docs.md`, [[1]](diffhunk://#diff-6a042219e4779f0e778edb839c177737f9d49be99d5032a644a5ae7cded83876L12-R23) [[2]](diffhunk://#diff-6a042219e4779f0e778edb839c177737f9d49be99d5032a644a5ae7cded83876L78-R94)